### PR TITLE
Fix GalleryScreen styles

### DIFF
--- a/src/screens/FeelingsScreen.tsx
+++ b/src/screens/FeelingsScreen.tsx
@@ -16,7 +16,7 @@ import {
   ];
   
   type Props = {
-    deviceName: 'Häschen' | 'Roter Panda';
+    deviceName: 'Hazechen' | 'Roter Panda';
   };
   
   export default function FeelingsScreen({ deviceName }: Props) {

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -76,3 +76,60 @@ export default function GalleryScreen() {
     </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f0f0f0',
+  },
+  gallery: {
+    padding: 10,
+    justifyContent: 'center',
+  },
+  image: {
+    width: '30%',
+    height: 100,
+    margin: 5,
+    borderRadius: 10,
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  slide: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fullImage: {
+    width: '100%',
+    height: '100%',
+  },
+  deleteButton: {
+    position: 'absolute',
+    top: 40,
+    right: 20,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    borderRadius: 20,
+    padding: 10,
+  },
+  deleteText: {
+    color: '#fff',
+    fontSize: 18,
+  },
+  fab: {
+    position: 'absolute',
+    bottom: 25,
+    right: 25,
+    backgroundColor: '#2196F3',
+    borderRadius: 30,
+    padding: 15,
+    elevation: 5,
+  },
+  fabText: {
+    color: '#fff',
+    fontSize: 24,
+  },
+});


### PR DESCRIPTION
## Summary
- add missing styles to `GalleryScreen`
- align role name in FeelingsScreen with rest of app

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684aca1bb05c832c8a529bddba16cfec