### PR TITLE
Fix FeelingsScreen props and cleanup imports

### DIFF
--- a/src/screens/FeelingsScreen.tsx
+++ b/src/screens/FeelingsScreen.tsx
@@ -8,65 +8,64 @@ import {
   Text,
   SafeAreaView,
 } from 'react-native';
-  const pandas = [
-    {id:1, name: 'Happy', image: require('../assets/pandas/happy.png') },
-    {id:2, name: 'Sad', image: require('../assets/pandas/sad.png') },
-    {id:3, name: 'Angry', image: require('../assets/pandas/angry.png') },
-    // usw...
-  ];
-  
-  type Props = {
-    deviceName: 'Häschen' | 'Roter Panda';
-  };
-  
-  export default function FeelingsScreen({ deviceName }: Props) {
-    return (
-      <SafeAreaView style={styles.safeArea}>
-        <View style={styles.background} />
-        <ScrollView contentContainerStyle={styles.container}>
-          {pandas.map((panda, index) => (
-            <TouchableOpacity
-              key={index}
-              onPress={() => console.log(`${panda.name} gedrückt`)}
-              style={styles.pandaWrapper}
-            >
-              <Image source={panda.image} style={styles.image} resizeMode="contain" />
-              <Text style={styles.label}>{panda.name}</Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
-      </SafeAreaView>
-    );
-  }
-  
-  const styles = StyleSheet.create({
-    safeArea: {
-      flex: 1,
-      backgroundColor: '#ccc', // Als Fallback
-    },
-    background: {
-      ...StyleSheet.absoluteFillObject,
-      backgroundColor: '#eeeeee', // Heller Grauton
-      zIndex: -1,
-    },
-    container: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      justifyContent: 'center',
-      paddingVertical: 20,
-    },
-    pandaWrapper: {
-      width: 100,
-      alignItems: 'center',
-      margin: 10,
-    },
-    image: {
-      width: 80,
-      height: 80,
-    },
-    label: {
-      marginTop: 5,
-      fontSize: 14,
-      color: '#333',
-    },
-  });
+const pandas = [
+  {id: 1, name: 'Happy', image: require('../assets/pandas/happy.png')},
+  {id: 2, name: 'Sad', image: require('../assets/pandas/sad.png')},
+  {id: 3, name: 'Angry', image: require('../assets/pandas/angry.png')},
+  // usw...
+];
+
+export default function FeelingsScreen() {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.background} />
+      <ScrollView contentContainerStyle={styles.container}>
+        {pandas.map((panda, index) => (
+          <TouchableOpacity
+            key={index}
+            onPress={() => console.log(`${panda.name} gedrückt`)}
+            style={styles.pandaWrapper}>
+            <Image
+              source={panda.image}
+              style={styles.image}
+              resizeMode="contain"
+            />
+            <Text style={styles.label}>{panda.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#ccc', // Als Fallback
+  },
+  background: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: '#eeeeee', // Heller Grauton
+    zIndex: -1,
+  },
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    paddingVertical: 20,
+  },
+  pandaWrapper: {
+    width: 100,
+    alignItems: 'center',
+    margin: 10,
+  },
+  image: {
+    width: 80,
+    height: 80,
+  },
+  label: {
+    marginTop: 5,
+    fontSize: 14,
+    color: '#333',
+  },
+});

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, {useState} from 'react';
 import {
   View,
   StyleSheet,
@@ -7,14 +7,10 @@ import {
   TouchableOpacity,
   Text,
   Modal,
-  Pressable,
 } from 'react-native';
-import Icon from 'react-native-vector-icons/MaterialIcons';
-import { launchImageLibrary } from 'react-native-image-picker';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { StatusBar } from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {StatusBar} from 'react-native';
 import Swiper from 'react-native-swiper';
-
 
 type GalleryItem = {
   id: string;
@@ -23,7 +19,7 @@ type GalleryItem = {
 
 export default function GalleryScreen() {
   const [images, setImages] = useState<GalleryItem[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null); 
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -33,10 +29,10 @@ export default function GalleryScreen() {
         numColumns={3}
         keyExtractor={item => item.id}
         contentContainerStyle={styles.gallery}
-        renderItem={({ item, index }) => (
+        renderItem={({item, index}) => (
           <TouchableOpacity onPress={() => setSelectedIndex(index)}>
             <Image
-              source={{ uri: `data:image/jpeg;base64,${item.image}` }}
+              source={{uri: `data:image/jpeg;base64,${item.image}`}}
               style={styles.image}
             />
           </TouchableOpacity>
@@ -45,30 +41,27 @@ export default function GalleryScreen() {
 
       {/* Modal für Fullscreen-Ansicht */}
       <Modal visible={selectedIndex !== null} transparent animationType="fade">
-  <View style={styles.overlay}>
-    <Swiper
-      loop={false}
-      index={selectedIndex ?? 0}
-      showsPagination={false}
-    >
-      {images.map((img, i) => (
-        <View key={img.id} style={styles.slide}>
-          <Image
-            source={{ uri: `data:image/jpeg;base64,${img.image}` }}
-            style={styles.fullImage}
-            resizeMode="contain"
-          />
+        <View style={styles.overlay}>
+          <Swiper
+            loop={false}
+            index={selectedIndex ?? 0}
+            showsPagination={false}>
+            {images.map((img, i) => (
+              <View key={img.id} style={styles.slide}>
+                <Image
+                  source={{uri: `data:image/jpeg;base64,${img.image}`}}
+                  style={styles.fullImage}
+                  resizeMode="contain"
+                />
+              </View>
+            ))}
+          </Swiper>
+
+          <TouchableOpacity style={styles.deleteButton} onPress={() => {}}>
+            <Text style={styles.deleteText}>🗑️</Text>
+          </TouchableOpacity>
         </View>
-      ))}
-    </Swiper>
-
-    <TouchableOpacity style={styles.deleteButton} onPress={() => {}}>
-  <Text style={styles.deleteText}>🗑️</Text>
-</TouchableOpacity>
-
-  </View>
-</Modal>
-
+      </Modal>
 
       <TouchableOpacity style={styles.fab} onPress={() => {}}>
         <Text style={styles.fabText}>＋</Text>
@@ -76,3 +69,60 @@ export default function GalleryScreen() {
     </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f0f0f0',
+  },
+  gallery: {
+    padding: 10,
+    justifyContent: 'center',
+  },
+  image: {
+    width: '30%',
+    height: 100,
+    margin: 5,
+    borderRadius: 10,
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  slide: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fullImage: {
+    width: '100%',
+    height: '100%',
+  },
+  deleteButton: {
+    position: 'absolute',
+    top: 40,
+    right: 20,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    borderRadius: 20,
+    padding: 10,
+  },
+  deleteText: {
+    color: '#fff',
+    fontSize: 18,
+  },
+  fab: {
+    position: 'absolute',
+    bottom: 25,
+    right: 25,
+    backgroundColor: '#2196F3',
+    borderRadius: 30,
+    padding: 15,
+    elevation: 5,
+  },
+  fabText: {
+    color: '#fff',
+    fontSize: 24,
+  },
+});


### PR DESCRIPTION
## Summary
- remove unused imports in `GalleryScreen`
- drop unused `deviceName` prop in `FeelingsScreen`
- format both screens with Prettier

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684aca1bb05c832c8a529bddba16cfec